### PR TITLE
feat: Implement coraza rules add file and coraza_rules_add_file

### DIFF
--- a/libcoraza/coraza.go
+++ b/libcoraza/coraza.go
@@ -6,6 +6,7 @@ package main
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <string.h>
 
 typedef struct coraza_intervention_t
 {
@@ -28,6 +29,7 @@ import "C"
 import (
 	"io"
 	"os"
+	"reflect"
 	"unsafe"
 
 	"github.com/corazawaf/coraza/v3"
@@ -68,7 +70,7 @@ func coraza_new_transaction(waf C.coraza_waf_t, logCb unsafe.Pointer) C.coraza_t
 //export coraza_new_transaction_with_id
 func coraza_new_transaction_with_id(waf C.coraza_waf_t, id *C.char, logCb unsafe.Pointer) C.coraza_transaction_t {
 	w := ptrToWaf(waf)
-	tx := w.NewTransactionWithID(C.GoString(id))
+	tx := w.NewTransactionWithID(MyCtostring(id))
 	ptr := transactionToPtr(tx)
 	txMap[ptr] = tx
 	return C.coraza_transaction_t(ptr)
@@ -89,9 +91,9 @@ func coraza_intervention(tx C.coraza_transaction_t) *C.coraza_intervention_t {
 //export coraza_process_connection
 func coraza_process_connection(t C.coraza_transaction_t, sourceAddress *C.char, clientPort C.int, serverHost *C.char, serverPort C.int) C.int {
 	tx := ptrToTransaction(t)
-	srcAddr := C.GoString(sourceAddress)
+	srcAddr := MyCtostring(sourceAddress)
 	cp := int(clientPort)
-	ch := C.GoString(serverHost)
+	ch := MyCtostring(serverHost)
 	sp := int(serverPort)
 	tx.ProcessConnection(srcAddr, cp, ch, sp)
 	return 0
@@ -120,14 +122,14 @@ func coraza_update_status_code(t C.coraza_transaction_t, code C.int) C.int {
 func coraza_process_uri(t C.coraza_transaction_t, uri *C.char, method *C.char, proto *C.char) C.int {
 	tx := ptrToTransaction(t)
 
-	tx.ProcessURI(C.GoString(uri), C.GoString(method), C.GoString(proto))
+	tx.ProcessURI(MyCtostring(uri), MyCtostring(method), MyCtostring(proto))
 	return 0
 }
 
 //export coraza_add_request_header
 func coraza_add_request_header(t C.coraza_transaction_t, name *C.char, name_len C.int, value *C.char, value_len C.int) C.int {
 	tx := ptrToTransaction(t)
-	tx.AddRequestHeader(C.GoStringN(name, name_len), C.GoStringN(value, value_len))
+	tx.AddRequestHeader(MyCtostringN(name, name_len), MyCtostringN(value, value_len))
 	return 0
 }
 
@@ -157,7 +159,7 @@ func coraza_append_request_body(t C.coraza_transaction_t, data *C.uchar, length 
 //export coraza_add_response_header
 func coraza_add_response_header(t C.coraza_transaction_t, name *C.char, name_len C.int, value *C.char, value_len C.int) C.int {
 	tx := ptrToTransaction(t)
-	tx.AddResponseHeader(C.GoStringN(name, name_len), C.GoStringN(value, value_len))
+	tx.AddResponseHeader(MyCtostringN(name, name_len), MyCtostringN(value, value_len))
 	return 0
 }
 
@@ -182,13 +184,13 @@ func coraza_process_response_body(t C.coraza_transaction_t) C.int {
 //export coraza_process_response_headers
 func coraza_process_response_headers(t C.coraza_transaction_t, status C.int, proto *C.char) C.int {
 	tx := ptrToTransaction(t)
-	tx.ProcessResponseHeaders(int(status), C.GoString(proto))
+	tx.ProcessResponseHeaders(int(status), MyCtostring(proto))
 	return 0
 }
 
 //export coraza_rules_add_file
 func coraza_rules_add_file(w C.coraza_waf_t, file *C.char, er **C.char) C.int {
-	conf := coraza.NewWAFConfig().WithDirectivesFromFile(C.GoString(file))
+	conf := coraza.NewWAFConfig().WithDirectivesFromFile(MyCtostring(file))
 	waf, err := coraza.NewWAF(conf)
 	if err != nil {
 		*er = C.CString(err.Error())
@@ -201,7 +203,7 @@ func coraza_rules_add_file(w C.coraza_waf_t, file *C.char, er **C.char) C.int {
 
 //export coraza_rules_add
 func coraza_rules_add(w C.coraza_waf_t, directives *C.char, er **C.char) C.int {
-	conf := coraza.NewWAFConfig().WithDirectives(C.GoString(directives))
+	conf := coraza.NewWAFConfig().WithDirectives(MyCtostring(directives))
 	waf, err := coraza.NewWAF(conf)
 	if err != nil {
 		*er = C.CString(err.Error())
@@ -247,7 +249,7 @@ func coraza_rules_merge(w1 C.coraza_waf_t, w2 C.coraza_waf_t, er **C.char) C.int
 //export coraza_request_body_from_file
 func coraza_request_body_from_file(t C.coraza_transaction_t, file *C.char) C.int {
 	tx := ptrToTransaction(t)
-	f, err := os.Open(C.GoString(file))
+	f, err := os.Open(MyCtostring(file))
 	if err != nil {
 		return 1
 	}
@@ -305,6 +307,31 @@ func wafToPtr(waf coraza.WAF) uint64 {
 // It should just be C.CString(s) but we need this to build tests
 func stringToC(s string) *C.char {
 	return C.CString(s)
+}
+
+func intToCint(i int) C.int {
+	return C.int(i)
+}
+
+// MyCtostring converts C string to Go string without copying data to enhance performance.
+func MyCtostring(cStr *C.char) string {
+
+	myStr := new(reflect.StringHeader)
+	// size_t strnlen(const char *s, size_t max_len);
+	cStrLen := C.strnlen(cStr, 65535) // invoke strnlen to obtain the len of cStr
+
+	myStr.Data = (uintptr)(unsafe.Pointer(cStr)) // the pointer of c char*
+	myStr.Len = int(cStrLen)                     // the length of c char *
+	gostr := *(*string)(unsafe.Pointer(myStr))
+	return gostr
+}
+
+func MyCtostringN(cStr *C.char, cLen C.int) string {
+	myStr := new(reflect.StringHeader)
+	myStr.Data = (uintptr)(unsafe.Pointer(cStr)) // the pointer of c char*
+	myStr.Len = int(cLen)                        // the length of c char *
+	gostr := *(*string)(unsafe.Pointer(myStr))
+	return gostr
 }
 
 func main() {}

--- a/libcoraza/coraza_test.go
+++ b/libcoraza/coraza_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/corazawaf/coraza/v3"
@@ -39,6 +40,25 @@ func TestTxCleaning(t *testing.T) {
 	coraza_free_transaction(txPtr)
 	if _, ok := txMap[uint64(txPtr)]; ok {
 		t.Fatal("Transaction was not removed from the map")
+	}
+}
+
+func TestMyCtostring(t *testing.T) {
+	testStr := "testtest"
+	testStrC := stringToC(testStr)
+	testStrGo := MyCtostring(testStrC)
+	if cmp := strings.Compare(testStr, testStrGo); cmp != 0 {
+		t.Fatal("There was a failure in converting C string to Go string using MyCtostring.")
+	}
+}
+
+func TestMyCtostringN(t *testing.T) {
+	testStr := "testtest"
+	testStrC := stringToC(testStr)
+	testStrLen := intToCint(len(testStr))
+	testStrGo := MyCtostringN(testStrC, testStrLen)
+	if cmp := strings.Compare(testStr, testStrGo); cmp != 0 {
+		t.Fatal("There was a failure in converting C string to Go string using MyCtostringN.")
 	}
 }
 

--- a/libcoraza/default.conf
+++ b/libcoraza/default.conf
@@ -1,0 +1,4 @@
+#SecDebugLogLevel 9
+#SecDebugLog /dev/stdout
+SecAuditEngine On
+SecRule REQUEST_HEADERS:User-Agent "Mozilla" "phase:1, id:3,drop,status:403,log,msg:'Blocked User-Agent'"


### PR DESCRIPTION
Implement coraza_rules_add and coraza_rules_add_file functions, which can dynamically add rules at any time.
such as 
```
er := stringToC("a")
waf := coraza_new_waf()
coraza_rules_add(waf, stringToC(`SecRule REQUEST_HEADERS:User-Agent "Mozilla" "phase:1, id:3,drop,status:403,log,msg:'Blocked User-Agent'"`), &er)
coraza_rules_add_file(waf, stringToC(`default.conf`), &er)
```