### PR TITLE
fixed: transactionToPtr always returns same transaction

### DIFF
--- a/libcoraza/coraza.go
+++ b/libcoraza/coraza.go
@@ -28,6 +28,7 @@ import "C"
 import (
 	"io"
 	"os"
+	"reflect"
 	"unsafe"
 
 	"github.com/corazawaf/coraza/v3"
@@ -293,13 +294,11 @@ func ptrToTransaction(t C.coraza_transaction_t) types.Transaction {
 }
 
 func transactionToPtr(tx types.Transaction) uint64 {
-	u := (*uint64)(unsafe.Pointer(&tx))
-	return *(*uint64)(unsafe.Pointer(&u))
+	return uint64(reflect.ValueOf(&tx).Pointer())
 }
 
 func wafToPtr(waf coraza.WAF) uint64 {
-	u := (*uint64)(unsafe.Pointer(&waf))
-	return *(*uint64)(unsafe.Pointer(&u))
+	return uint64(reflect.ValueOf(&waf).Pointer())
 }
 
 // It should just be C.CString(s) but we need this to build tests

--- a/libcoraza/coraza.go
+++ b/libcoraza/coraza.go
@@ -294,7 +294,7 @@ func ptrToTransaction(t C.coraza_transaction_t) types.Transaction {
 
 func transactionToPtr(tx types.Transaction) uint64 {
 	u := (*uint64)(unsafe.Pointer(&tx))
-	return *u
+	return *(*uint64)(unsafe.Pointer(&u))
 }
 
 func wafToPtr(waf coraza.WAF) uint64 {

--- a/libcoraza/coraza.go
+++ b/libcoraza/coraza.go
@@ -299,7 +299,7 @@ func transactionToPtr(tx types.Transaction) uint64 {
 
 func wafToPtr(waf coraza.WAF) uint64 {
 	u := (*uint64)(unsafe.Pointer(&waf))
-	return *u
+	return *(*uint64)(unsafe.Pointer(&u))
 }
 
 // It should just be C.CString(s) but we need this to build tests

--- a/libcoraza/coraza_test.go
+++ b/libcoraza/coraza_test.go
@@ -29,6 +29,10 @@ func TestTransactionInitialization(t *testing.T) {
 	if tt == 0 {
 		t.Fatal("Transaction initialization failed")
 	}
+	t2 := coraza_new_transaction(waf, nil)
+	if t2 == tt {
+		t.Fatal("Transactions are duplicated")
+	}
 	tx := ptrToTransaction(tt)
 	tx.ProcessConnection("127.0.0.1", 8080, "127.0.0.1", 80)
 }


### PR DESCRIPTION
transactionToPtr always returns same transaction. In function, poiner u is different when the function is called. But pointer u refers same address. Hence transaction is always duplicate.