### PR TITLE
fixed: freed wild pointer cause panic

### DIFF
--- a/libcoraza/coraza.go
+++ b/libcoraza/coraza.go
@@ -234,8 +234,6 @@ func coraza_free_intervention(it *C.coraza_intervention_t) C.int {
 		return 1
 	}
 	defer C.free(unsafe.Pointer(it))
-	C.free(unsafe.Pointer(it.log))
-	C.free(unsafe.Pointer(it.url))
 	C.free(unsafe.Pointer(it.action))
 	return 0
 }

--- a/libcoraza/coraza.go
+++ b/libcoraza/coraza.go
@@ -10,8 +10,6 @@ package main
 typedef struct coraza_intervention_t
 {
 	char *action;
-	char *log;
-    char *url;
     int status;
     int pause;
     int disruptive;


### PR DESCRIPTION
In apisix with ubuntu 22.04 arm64,  when i called coraza_free_intervention may cause panic. because `it.url` and `it.log` are wild pointer.  Macos isn't going to happen. 
<img width="1228" alt="Pasted Graphic" src="https://github.com/corazawaf/libcoraza/assets/42128471/0efdd2b3-4883-4649-88af-1135c3994d5e">
