### PR TITLE
feat: add  coraza_add_get_args to expose tx.AddGetRequestArgument

### DIFF
--- a/libcoraza/coraza.go
+++ b/libcoraza/coraza.go
@@ -153,6 +153,13 @@ func coraza_append_request_body(t C.coraza_transaction_t, data *C.uchar, length 
 	return 0
 }
 
+//export coraza_add_get_args
+func coraza_add_get_args(t C.coraza_transaction_t, name *C.char, value *C.char) C.int {
+	tx := ptrToTransaction(t)
+	tx.AddGetRequestArgument(C.GoString(name), C.GoString(value))
+	return 0
+}
+
 //export coraza_add_response_header
 func coraza_add_response_header(t C.coraza_transaction_t, name *C.char, name_len C.int, value *C.char, value_len C.int) C.int {
 	tx := ptrToTransaction(t)

--- a/libcoraza/coraza_test.go
+++ b/libcoraza/coraza_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/corazawaf/coraza/v3"
+	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 )
 
 var waf *coraza.WAF
@@ -21,6 +22,29 @@ func TestWafIsConsistent(t *testing.T) {
 }
 
 func TestAddRulesToWaf(t *testing.T) {
+}
+
+func TestCoraza_add_get_args(t *testing.T) {
+	waf := coraza_new_waf()
+	tt := coraza_new_transaction(waf, nil)
+	coraza_add_get_args(tt, stringToC("aa"), stringToC("bb"))
+	tx := ptrToTransaction(tt)
+	txi := tx.(plugintypes.TransactionState)
+	argsGet := txi.Variables().ArgsGet()
+	value := argsGet.Get("aa")
+	if len(value) != 1 && value[0] != "bb" {
+		t.Fatal("coraza_add_get_args can't add args")
+	}
+	coraza_add_get_args(tt, stringToC("dd"), stringToC("ee"))
+	value = argsGet.Get("dd")
+	if len(value) != 1 && value[0] != "ee" {
+		t.Fatal("coraza_add_get_args can't add args with another key")
+	}
+	coraza_add_get_args(tt, stringToC("aa"), stringToC("cc"))
+	value = argsGet.Get("aa")
+	if len(value) != 2 && value[0] != "bb" && value[1] != "cc" {
+		t.Fatal("coraza_add_get_args can't add args with same key more than once")
+	}
 }
 
 func TestTransactionInitialization(t *testing.T) {


### PR DESCRIPTION
in libcoraza, we can't add http args.  Now we only add http args by ProcessURI. But in ProcessURI func docs, it says that `This function won't add GET arguments, they must be added with AddArgument`.

therefore, I opened a PR to expose AddGetRequestArgument.