### PR TITLE
Make allocations thread safe

### DIFF
--- a/libcoraza/coraza_test.go
+++ b/libcoraza/coraza_test.go
@@ -65,7 +65,7 @@ func TestTxCleaning(t *testing.T) {
 	waf := coraza_new_waf()
 	txPtr := coraza_new_transaction(waf, nil)
 	coraza_free_transaction(txPtr)
-	if _, ok := txMap[uint64(txPtr)]; ok {
+	if _, ok := txMap.Load(uint64(txPtr)); ok {
 		t.Fatal("Transaction was not removed from the map")
 	}
 }


### PR DESCRIPTION
Currently, calling `coraza_new_waf` and `coraza_new_transaction` and their deallocation counterparts are not thread safe due to modifying a standard go map. This PR switches them out for [sync.Map](https://pkg.go.dev/sync#Map).

According to the docs:
> The Map type is optimized for two common use cases: (1) when the entry for a given key is only ever written once but read many times, as in caches that only grow, or (2) when multiple goroutines read, write, and overwrite entries for disjoint sets of keys. In these two cases, use of a Map may significantly reduce lock contention compared to a Go map paired with a separate [Mutex](https://pkg.go.dev/sync#Mutex) or [RWMutex](https://pkg.go.dev/sync#RWMutex).

Given that the keys are simply casted from the reference types, this should make key collision very rare.