### PR TITLE
feat: implement waf config type

### DIFF
--- a/tests/simple_get.c
+++ b/tests/simple_get.c
@@ -10,6 +10,14 @@ void logcb(const void *data)
 
 int main()
 {
+    coraza_waf_config_t config = coraza_new_waf_config();
+    if (config == 0) {
+        printf("Failed to create config\n");
+        return 1;
+    }
+    printf("Compiling rules...\n");
+    coraza_rules_add(config, "SecRule REMOTE_ADDR \"127.0.0.1\" \"id:1,phase:1,deny,log,msg:'test 123',status:403\"");
+
     coraza_waf_t waf = 0;
     coraza_transaction_t tx = 0;
     coraza_intervention_t *intervention = NULL;
@@ -17,20 +25,17 @@ int main()
     char ** uri = NULL;
 
     printf("Starting...\n");
-    waf = coraza_new_waf();
+    waf = coraza_new_waf(config, &err);
+    if (err) {
+        printf("%s\n", err);
+        return 1;
+    }
     if (waf == 0) {
         printf("Failed to create waf\n");
         return 1;
     }
     printf("Attaching log callback\n");
     coraza_set_log_cb(waf, logcb);
-
-    printf("Compiling rules...\n");
-    coraza_rules_add(waf, "SecRule REMOTE_ADDR \"127.0.0.1\" \"id:1,phase:1,deny,log,msg:'test 123',status:403\"", &err);
-    if(err) {
-        printf("%s\n", err);
-        return 1;
-    }
 
     printf("%d rules compiled\n", coraza_rules_count(waf));
     printf("Creating transaction...\n");
@@ -69,6 +74,7 @@ int main()
         return 1;
     }
     coraza_free_waf(waf);
+    coraza_free_waf_config(config);
     coraza_free_intervention(intervention);
     return 0;
 }


### PR DESCRIPTION
Currently, to configure the waf, the api modifies the waf in place. I propose instead we expose a config instead to configure rules (and in the future the logging callbacks). This will be more ergonomic and efficient once more config methods are exposed.

Misc: change handle types from uint64 to uintptr. In practice, this should be the same type on 64-bit architectures.