### PR TITLE
feat: support debugger callbacks

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -50,4 +50,4 @@ tests_simple_get_LDADD = ./libcoraza.a
 
 check: tests/simple_get
 	go test -race ./...
-	./tests/simple_get
+	cd tests && ./check_result.sh simple_get

--- a/libcoraza/coraza_test.go
+++ b/libcoraza/coraza_test.go
@@ -38,7 +38,7 @@ func TestAddRulesToWaf(t *testing.T) {
 func TestCoraza_add_get_args(t *testing.T) {
 	config := coraza_new_waf_config()
 	waf := coraza_new_waf(config, nil)
-	tt := coraza_new_transaction(waf, nil)
+	tt := coraza_new_transaction(waf)
 	coraza_add_get_args(tt, stringToC("aa"), stringToC("bb"))
 	tx := cgo.Handle(tt).Value().(types.Transaction)
 	txi := tx.(plugintypes.TransactionState)
@@ -62,11 +62,11 @@ func TestCoraza_add_get_args(t *testing.T) {
 func TestTransactionInitialization(t *testing.T) {
 	config := coraza_new_waf_config()
 	waf := coraza_new_waf(config, nil)
-	tt := coraza_new_transaction(waf, nil)
+	tt := coraza_new_transaction(waf)
 	if tt == 0 {
 		t.Fatal("Transaction initialization failed")
 	}
-	t2 := coraza_new_transaction(waf, nil)
+	t2 := coraza_new_transaction(waf)
 	if t2 == tt {
 		t.Fatal("Transactions are duplicated")
 	}
@@ -96,7 +96,7 @@ func TestMultipleTransactionsAllocatedDeallocated(t *testing.T) {
 	waf := coraza_new_waf(config, nil)
 	txes := make([]cgo.Handle, numTransactions)
 	for i := 0; i < numTransactions; i++ {
-		txes[i] = cgo.Handle(coraza_new_transaction(waf, nil))
+		txes[i] = cgo.Handle(coraza_new_transaction(waf))
 	}
 	// free every other transaction while performing an operation on the other transaction
 	// if there are any collisions between handles, this will result in a seg fault
@@ -120,7 +120,7 @@ func TestMultipleWafsAllocatedDeallocated(t *testing.T) {
 	// free every other waf while performing an operation on the other waf
 	// if there are any collisions between handles, this will result in a seg fault
 	for i := 1; i < numWafs; i += 2 {
-		coraza_new_transaction(wafFromCgoHandle(cgo.Handle(wafs[i-1])), nil)
+		coraza_new_transaction(wafFromCgoHandle(cgo.Handle(wafs[i-1])))
 		coraza_free_waf(wafFromCgoHandle(cgo.Handle(wafs[i])))
 	}
 	for i := 0; i < numWafs; i += 2 {
@@ -208,7 +208,7 @@ func TestParallelWafs(t *testing.T) {
 			}
 
 			// create a transaction
-			tt := coraza_new_transaction(waf, nil)
+			tt := coraza_new_transaction(waf)
 			if tt == 0 {
 				return errors.New("Transaction initialization failed")
 			}
@@ -270,7 +270,7 @@ func TestParallelTransactions(t *testing.T) {
 
 			// initialize the transaction
 			runtime.GC()
-			tt := coraza_new_transaction(waf, nil)
+			tt := coraza_new_transaction(waf)
 			if tt == 0 {
 				return errors.New("Transaction initialization failed")
 			}
@@ -314,7 +314,7 @@ func BenchmarkTransactionCreation(b *testing.B) {
 	config := coraza_new_waf_config()
 	waf := coraza_new_waf(config, nil)
 	for i := 0; i < b.N; i++ {
-		coraza_new_transaction(waf, nil)
+		coraza_new_transaction(waf)
 	}
 }
 
@@ -323,7 +323,7 @@ func BenchmarkTransactionProcessing(b *testing.B) {
 	coraza_rules_add(config, stringToC(`SecRule UNIQUE_ID "" "id:1"`))
 	waf := coraza_new_waf(config, nil)
 	for i := 0; i < b.N; i++ {
-		txPtr := coraza_new_transaction(waf, nil)
+		txPtr := coraza_new_transaction(waf)
 		tx := cgo.Handle(txPtr).Value().(types.Transaction)
 		tx.ProcessConnection("127.0.0.1", 55555, "127.0.0.1", 80)
 		tx.ProcessURI("https://www.example.com/some?params=123", "GET", "HTTP/1.1")

--- a/libcoraza/log.go
+++ b/libcoraza/log.go
@@ -1,10 +1,46 @@
 package main
 
-/*
-typedef void (*coraza_log_cb) (const void *);
-
-void send_log_to_cb(coraza_log_cb cb, const char *msg){
-	cb(msg);
-}
-*/
 import "C"
+import (
+	"io"
+	"log"
+
+	"github.com/corazawaf/coraza/v3/debuglog"
+)
+
+var _ debuglog.Logger = logger{}
+
+type logger struct {
+	debuglog.Logger
+	writer io.Writer
+}
+
+var _ debuglog.Logger = logger{}
+
+func newDebugLogger(defaultPrinter debuglog.Printer) debuglog.Logger {
+	logger := logger{
+		writer: nil,
+	}
+	logger.Logger = debuglog.DefaultWithPrinterFactory(func(w io.Writer) debuglog.Printer {
+		if logger.writer != nil {
+			return func(lvl debuglog.Level, message, fields string) {
+				log.New(logger.writer, "", log.LstdFlags).Printf("[%s] %s %s", lvl.String(), message, fields)
+			}
+		}
+		return defaultPrinter
+	})
+	return logger
+}
+
+func (l logger) WithLevel(lvl debuglog.Level) debuglog.Logger {
+	return logger{
+		Logger: l.Logger.WithLevel(lvl),
+	}
+}
+
+func (l logger) WithOutput(w io.Writer) debuglog.Logger {
+	return logger{
+		Logger: l,
+		writer: w,
+	}
+}

--- a/tests/check_result.sh
+++ b/tests/check_result.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Check that we have an argument
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <executable_name>"
+    exit 1
+fi
+
+EXECUTABLE_NAME="$1"
+EXECUTABLE="./${EXECUTABLE_NAME}"
+OUT_FILE="./${EXECUTABLE_NAME}.out"
+
+# Check if executable exists
+if [ ! -f "$EXECUTABLE" ]; then
+    echo "Error: Executable '$EXECUTABLE' not found"
+    exit 1
+fi
+
+# Check if .out file exists
+if [ ! -f "$OUT_FILE" ]; then
+    echo "Error: Expected output file '$OUT_FILE' not found"
+    exit 1
+fi
+
+# Run the executable and capture output to environment variable
+ACTUAL_OUTPUT=$("$EXECUTABLE" 2>&1)
+EXIT_CODE=$?
+
+# Check if execution was successful
+if [ $EXIT_CODE -ne 0 ]; then
+    echo "Error: Executable '$EXECUTABLE_NAME' exited with code $EXIT_CODE"
+    exit 1
+fi
+
+# Compare output with expected output using diff
+if diff -u <(cat "$OUT_FILE") <(printf '%s\n' "$ACTUAL_OUTPUT") > /dev/null; then
+    echo "PASS: Output matches expected output"
+    exit 0
+else
+    echo "FAIL: Output does not match expected output"
+    echo ""
+    diff -u <(cat "$OUT_FILE") <(printf '%s\n' "$ACTUAL_OUTPUT")
+    exit 1
+fi
+

--- a/tests/simple_get.c
+++ b/tests/simple_get.c
@@ -2,9 +2,9 @@
 
 #include "coraza/coraza.h"
 
-void logcb(const void *data)
+void logcb(void *context, coraza_debug_log_level_t level, const char *msg, const char *fields)
 {
-    printf("%s\n", (const char *)data);
+    printf("[%s][level %d] %s %s\n", (const char *)context, level, msg, fields);
 }
 
 
@@ -17,6 +17,9 @@ int main()
     }
     printf("Compiling rules...\n");
     coraza_rules_add(config, "SecRule REMOTE_ADDR \"127.0.0.1\" \"id:1,phase:1,deny,log,msg:'test 123',status:403\"");
+
+    printf("Attaching log callback\n");
+    coraza_add_debug_log_callback(config, logcb, "simple_get");
 
     coraza_waf_t waf = 0;
     coraza_transaction_t tx = 0;
@@ -34,12 +37,10 @@ int main()
         printf("Failed to create waf\n");
         return 1;
     }
-    printf("Attaching log callback\n");
-    coraza_set_log_cb(waf, logcb);
 
     printf("%d rules compiled\n", coraza_rules_count(waf));
     printf("Creating transaction...\n");
-    tx = coraza_new_transaction(waf, NULL);
+    tx = coraza_new_transaction_with_id(waf, "simple_get");
     if(tx == 0) {
         printf("Failed to create transaction\n");
         return 1;

--- a/tests/simple_get.out
+++ b/tests/simple_get.out
@@ -1,0 +1,17 @@
+Compiling rules...
+Attaching log callback
+Starting...
+0 rules compiled
+Creating transaction...
+Processing connection...
+Processing request line
+Processing phase 1
+Processing phase 2
+[simple_get][level 4] Calling ProcessRequestBody but there is a preexisting interruption tx_id="simple_get"
+Processing phase 3
+[simple_get][level 4] Calling ProcessResponseHeaders but there is a preexisting interruption tx_id="simple_get"
+Processing phase 4
+[simple_get][level 4] Calling ProcessResponseBody but there is a preexisting interruption tx_id="simple_get"
+Processing phase 5
+Processing intervention
+Transaction disrupted with status 403


### PR DESCRIPTION
This defines the callback 
```
typedef void (*coraza_debug_log_cb) (void *, coraza_debug_log_level_t, const char *msg, const char *fields);
```
used to intercept debug logs made by coraza. 

The first `void*` allows for user contexts, allowing users to provide a closure-like callback which can be useful if the programmer wants to have a unique context per config instance and the config instances are unknown at runtime.

It is difficult to test this in go without exporting test C functions, so instead a script is used that compares the expected output.