### PR TITLE
chore(ci): harden GHA workflows with least-privilege permissions

### DIFF
--- a/.github/workflows/make-install.yml
+++ b/.github/workflows/make-install.yml
@@ -3,8 +3,14 @@ name: Test make and install
 on:
   push:
   pull_request:
+    branches: [main]
+
+permissions: {}
+
 jobs:
   make-targets:
+    permissions:
+      contents: read
     strategy:
       matrix:
         go-version: [1.25.x, 1.26.x]

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,15 +3,16 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+permissions: {}
 
 name: release-please
 
 jobs:
   release-please:
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4


### PR DESCRIPTION
## Summary
- Add top-level `permissions: {}` (deny-all default) to all workflows
- Add job-level scoped permissions appropriate for each job
- Move existing top-level permissions in `release-please.yml` to job-level
- Add `branches: [main]` to `pull_request` trigger in `make-install.yml`