### PR TITLE
fix(tests): update expected severity for coraza v3.7.0

### DIFF
--- a/tests/simple_get.out
+++ b/tests/simple_get.out
@@ -7,7 +7,7 @@ Creating transaction...
 Processing connection...
 Processing request line
 Processing phase 1
-[simple_get][severity 8] [client "127.0.0.1"] Coraza: Access denied (phase 1). test 123 [file "_inline_"] [line "1"] [id "1"] [rev ""] [msg "test 123"] [data ""] [severity "emergency"] [ver ""] [maturity "0"] [accuracy "0"] [hostname ""] [uri "/someurl"] [unique_id "simple_get"]
+[simple_get][severity 0] [client "127.0.0.1"] Coraza: Access denied (phase 1). test 123 [file "_inline_"] [line "1"] [id "1"] [rev ""] [msg "test 123"] [data ""] [severity "unknown"] [ver ""] [maturity "0"] [accuracy "0"] [hostname ""] [uri "/someurl"] [unique_id "simple_get"]
 Processing phase 2
 [simple_get][level 5] Calling ProcessRequestBody but there is a preexisting interruption tx_id="simple_get"
 Processing phase 3


### PR DESCRIPTION
Coraza v3.7.0 changed the default severity for rules without an
explicit severity action from 8 ("emergency") to 0 ("unknown").

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>