### PR TITLE
feat: add coraza_is_response_body_processable() API

### DIFF
--- a/coraza.i
+++ b/coraza.i
@@ -388,6 +388,7 @@ extern int coraza_add_response_header(coraza_transaction_t t,
 extern int coraza_append_response_body(coraza_transaction_t t,
                                        const unsigned char *data, int length);
 extern int coraza_process_response_body(coraza_transaction_t t);
+extern int coraza_is_response_body_processable(coraza_transaction_t t);
 extern int coraza_process_response_headers(coraza_transaction_t t, int status,
                                            const char *proto);
 extern int coraza_rules_count(coraza_waf_t w);

--- a/libcoraza/coraza.go
+++ b/libcoraza/coraza.go
@@ -339,6 +339,15 @@ func coraza_process_response_headers(t C.coraza_transaction_t, status C.int, pro
 	return 0
 }
 
+//export coraza_is_response_body_processable
+func coraza_is_response_body_processable(t C.coraza_transaction_t) C.int {
+	tx := fromRaw[types.Transaction](t)
+	if tx.IsResponseBodyProcessable() {
+		return 1
+	}
+	return 0
+}
+
 //export coraza_rules_count
 func coraza_rules_count(w C.coraza_waf_t) C.int {
 	handle := fromRaw[*WafHandle](w)


### PR DESCRIPTION
Exposes the Go engine's `IsResponseBodyProcessable()` through the C API so connectors (nginx, apache) can skip response body processing when `SecResponseBodyAccess` is Off or the response Content-Type doesn't match `SecResponseBodyMimeType`.

Returns 1 if the body should be processed, 0 otherwise. Must be called after `coraza_process_response_headers()`.

Related: corazawaf/coraza-nginx#41 (large response hang) and corazawaf/coraza-nginx#42 (nginx fix that uses this API).

cc @fzipi @jptosso

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to check whether a transaction's response body can be processed, enabling callers to verify processability before invoking response-body processing operations.
  * Improves safety and flow control for integrations that conditionally handle response bodies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->