### PR TITLE
feat(api): return 1 on disruption, add bulk headers, add coraza_free_string

### DIFF
--- a/coraza.i
+++ b/coraza.i
@@ -330,6 +330,12 @@ typedef struct coraza_intervention_t {
     char *data;
 } coraza_intervention_t;
 
+typedef enum coraza_result_t {
+    CORAZA_ERROR = -1,
+    CORAZA_OK = 0,
+    CORAZA_INTERRUPTION = 1,
+} coraza_result_t;
+
 typedef enum coraza_debug_log_level_t {
     CORAZA_DEBUG_LOG_LEVEL_UNKNOWN,
     CORAZA_DEBUG_LOG_LEVEL_TRACE,

--- a/coraza.i
+++ b/coraza.i
@@ -401,3 +401,10 @@ extern int coraza_free_waf(coraza_waf_t t);
 extern coraza_severity_t coraza_matched_rule_get_severity(
     coraza_matched_rule_t r);
 extern char *coraza_matched_rule_get_error_log(coraza_matched_rule_t r);
+extern int coraza_add_request_headers(coraza_transaction_t t,
+                                      const char *packed, int packed_len,
+                                      int count);
+extern int coraza_add_response_headers(coraza_transaction_t t,
+                                       const char *packed, int packed_len,
+                                       int count);
+extern void coraza_free_string(char *s);

--- a/coraza.i
+++ b/coraza.i
@@ -25,6 +25,7 @@
  */
 %ignore coraza_add_debug_log_callback;
 %ignore coraza_add_error_callback;
+%ignore coraza_free_string;
 
 /*
  * Handle the char** output parameter for error messages.

--- a/examples/java/SimpleGet.java
+++ b/examples/java/SimpleGet.java
@@ -102,9 +102,9 @@ public class SimpleGet {
             ret = coraza.coraza_process_uri(tx, "/someurl?foo=bar", "GET", "HTTP/1.1");
             check(ret == 0, "coraza_process_uri failed: " + ret);
 
-            // coraza_process_request_headers
+            // coraza_process_request_headers (returns 1 when interrupted by a deny rule)
             ret = coraza.coraza_process_request_headers(tx);
-            check(ret == 0, "coraza_process_request_headers failed: " + ret);
+            check(ret >= 0, "coraza_process_request_headers failed: " + ret);
 
             // coraza_append_request_body (byte[] typemap: single array arg)
             ret = coraza.coraza_append_request_body(tx, "hello=world".getBytes());
@@ -112,11 +112,11 @@ public class SimpleGet {
 
             // coraza_process_request_body
             ret = coraza.coraza_process_request_body(tx);
-            check(ret == 0, "coraza_process_request_body failed: " + ret);
+            check(ret >= 0, "coraza_process_request_body failed: " + ret);
 
             // coraza_process_response_headers
             ret = coraza.coraza_process_response_headers(tx, 200, "HTTP/1.1");
-            check(ret == 0, "coraza_process_response_headers failed: " + ret);
+            check(ret >= 0, "coraza_process_response_headers failed: " + ret);
 
             // coraza_add_response_header
             String cname = "Content-Type", cvalue = "text/plain";
@@ -130,7 +130,7 @@ public class SimpleGet {
 
             // coraza_process_response_body
             ret = coraza.coraza_process_response_body(tx);
-            check(ret == 0, "coraza_process_response_body failed: " + ret);
+            check(ret >= 0, "coraza_process_response_body failed: " + ret);
 
             // coraza_update_status_code
             coraza.coraza_update_status_code(tx, 200);

--- a/examples/java/SimpleGet.java
+++ b/examples/java/SimpleGet.java
@@ -102,9 +102,9 @@ public class SimpleGet {
             ret = coraza.coraza_process_uri(tx, "/someurl?foo=bar", "GET", "HTTP/1.1");
             check(ret == 0, "coraza_process_uri failed: " + ret);
 
-            // coraza_process_request_headers (returns 1 when interrupted by a deny rule)
+            // coraza_process_request_headers (returns CORAZA_INTERRUPTION for the deny rule)
             ret = coraza.coraza_process_request_headers(tx);
-            check(ret >= 0, "coraza_process_request_headers failed: " + ret);
+            check(ret == 1, "coraza_process_request_headers: expected CORAZA_INTERRUPTION (1), got " + ret);
 
             // coraza_append_request_body (byte[] typemap: single array arg)
             ret = coraza.coraza_append_request_body(tx, "hello=world".getBytes());

--- a/examples/python/simple_get.py
+++ b/examples/python/simple_get.py
@@ -198,9 +198,9 @@ def test_request_body_from_file():
     finally:
         os.unlink(body_file)
 
-    _check(_c.coraza_process_request_body(tx) == 0, "coraza_process_request_body failed")
-    _check(_c.coraza_process_response_headers(tx, 200, "HTTP/1.1") == 0, "coraza_process_response_headers failed")
-    _check(_c.coraza_process_response_body(tx) == 0, "coraza_process_response_body failed")
+    _check(_c.coraza_process_request_body(tx) >= 0, "coraza_process_request_body failed")
+    _check(_c.coraza_process_response_headers(tx, 200, "HTTP/1.1") >= 0, "coraza_process_response_headers failed")
+    _check(_c.coraza_process_response_body(tx) >= 0, "coraza_process_response_body failed")
     _check(_c.coraza_process_logging(tx) == 0, "coraza_process_logging failed")
     _check(_c.coraza_free_transaction(tx) == 0, "coraza_free_transaction failed")
     _check(_c.coraza_free_waf(waf) == 0, "coraza_free_waf failed")

--- a/examples/python/simple_get.py
+++ b/examples/python/simple_get.py
@@ -108,9 +108,9 @@ def test_lifecycle():
     ret = _c.coraza_process_uri(tx, "/someurl?foo=bar", "GET", "HTTP/1.1")
     _check(ret == 0, f"coraza_process_uri failed: {ret}")
 
-    # coraza_process_request_headers
+    # coraza_process_request_headers (returns 1 when interrupted by a deny rule)
     ret = _c.coraza_process_request_headers(tx)
-    _check(ret == 0, f"coraza_process_request_headers failed: {ret}")
+    _check(ret >= 0, f"coraza_process_request_headers failed: {ret}")
 
     # coraza_append_request_body (bytes typemap: single argument)
     body = b"hello=world"
@@ -119,11 +119,11 @@ def test_lifecycle():
 
     # coraza_process_request_body
     ret = _c.coraza_process_request_body(tx)
-    _check(ret == 0, f"coraza_process_request_body failed: {ret}")
+    _check(ret >= 0, f"coraza_process_request_body failed: {ret}")
 
     # coraza_process_response_headers
     ret = _c.coraza_process_response_headers(tx, 200, "HTTP/1.1")
-    _check(ret == 0, f"coraza_process_response_headers failed: {ret}")
+    _check(ret >= 0, f"coraza_process_response_headers failed: {ret}")
 
     # coraza_add_response_header
     cname, cvalue = "Content-Type", "text/plain"
@@ -139,7 +139,7 @@ def test_lifecycle():
 
     # coraza_process_response_body
     ret = _c.coraza_process_response_body(tx)
-    _check(ret == 0, f"coraza_process_response_body failed: {ret}")
+    _check(ret >= 0, f"coraza_process_response_body failed: {ret}")
 
     # coraza_update_status_code
     _c.coraza_update_status_code(tx, 200)

--- a/examples/python/simple_get.py
+++ b/examples/python/simple_get.py
@@ -198,9 +198,9 @@ def test_request_body_from_file():
     finally:
         os.unlink(body_file)
 
-    _check(_c.coraza_process_request_body(tx) >= 0, "coraza_process_request_body failed")
-    _check(_c.coraza_process_response_headers(tx, 200, "HTTP/1.1") >= 0, "coraza_process_response_headers failed")
-    _check(_c.coraza_process_response_body(tx) >= 0, "coraza_process_response_body failed")
+    _check(_c.coraza_process_request_body(tx) == 0, "coraza_process_request_body failed")
+    _check(_c.coraza_process_response_headers(tx, 200, "HTTP/1.1") == 0, "coraza_process_response_headers failed")
+    _check(_c.coraza_process_response_body(tx) == 0, "coraza_process_response_body failed")
     _check(_c.coraza_process_logging(tx) == 0, "coraza_process_logging failed")
     _check(_c.coraza_free_transaction(tx) == 0, "coraza_free_transaction failed")
     _check(_c.coraza_free_waf(waf) == 0, "coraza_free_waf failed")

--- a/examples/python/simple_get.py
+++ b/examples/python/simple_get.py
@@ -108,9 +108,9 @@ def test_lifecycle():
     ret = _c.coraza_process_uri(tx, "/someurl?foo=bar", "GET", "HTTP/1.1")
     _check(ret == 0, f"coraza_process_uri failed: {ret}")
 
-    # coraza_process_request_headers (returns 1 when interrupted by a deny rule)
+    # coraza_process_request_headers (returns CORAZA_INTERRUPTION for the deny rule)
     ret = _c.coraza_process_request_headers(tx)
-    _check(ret >= 0, f"coraza_process_request_headers failed: {ret}")
+    _check(ret == 1, f"coraza_process_request_headers: expected CORAZA_INTERRUPTION (1), got {ret}")
 
     # coraza_append_request_body (bytes typemap: single argument)
     body = b"hello=world"

--- a/libcoraza/coraza.go
+++ b/libcoraza/coraza.go
@@ -22,6 +22,12 @@ typedef uintptr_t coraza_waf_t;
 typedef uintptr_t coraza_transaction_t;
 typedef uintptr_t coraza_matched_rule_t;
 
+typedef enum coraza_result_t {
+	CORAZA_ERROR = -1,
+	CORAZA_OK = 0,
+	CORAZA_INTERRUPTION = 1,
+} coraza_result_t;
+
 typedef enum coraza_debug_log_level_t {
 	CORAZA_DEBUG_LOG_LEVEL_UNKNOWN,
 	CORAZA_DEBUG_LOG_LEVEL_TRACE,
@@ -241,12 +247,12 @@ func coraza_process_request_body(t C.coraza_transaction_t) C.int {
 	tx := fromRaw[types.Transaction](t)
 	it, err := tx.ProcessRequestBody()
 	if err != nil {
-		return -1
+		return C.CORAZA_ERROR
 	}
 	if it != nil {
-		return 1
+		return C.CORAZA_INTERRUPTION
 	}
-	return 0
+	return C.CORAZA_OK
 }
 
 //export coraza_update_status_code
@@ -322,9 +328,9 @@ func coraza_add_request_headers(t C.coraza_transaction_t, packed *C.char, packed
 func coraza_process_request_headers(t C.coraza_transaction_t) C.int {
 	tx := fromRaw[types.Transaction](t)
 	if it := tx.ProcessRequestHeaders(); it != nil {
-		return 1
+		return C.CORAZA_INTERRUPTION
 	}
-	return 0
+	return C.CORAZA_OK
 }
 
 //export coraza_process_logging
@@ -408,21 +414,21 @@ func coraza_process_response_body(t C.coraza_transaction_t) C.int {
 	tx := fromRaw[types.Transaction](t)
 	it, err := tx.ProcessResponseBody()
 	if err != nil {
-		return -1
+		return C.CORAZA_ERROR
 	}
 	if it != nil {
-		return 1
+		return C.CORAZA_INTERRUPTION
 	}
-	return 0
+	return C.CORAZA_OK
 }
 
 //export coraza_process_response_headers
 func coraza_process_response_headers(t C.coraza_transaction_t, status C.int, proto *C.char) C.int {
 	tx := fromRaw[types.Transaction](t)
 	if it := tx.ProcessResponseHeaders(int(status), C.GoString(proto)); it != nil {
-		return 1
+		return C.CORAZA_INTERRUPTION
 	}
-	return 0
+	return C.CORAZA_OK
 }
 
 //export coraza_is_response_body_processable

--- a/libcoraza/coraza.go
+++ b/libcoraza/coraza.go
@@ -239,7 +239,11 @@ func coraza_process_connection(t C.coraza_transaction_t, sourceAddress *C.char, 
 //export coraza_process_request_body
 func coraza_process_request_body(t C.coraza_transaction_t) C.int {
 	tx := fromRaw[types.Transaction](t)
-	if _, err := tx.ProcessRequestBody(); err != nil {
+	it, err := tx.ProcessRequestBody()
+	if err != nil {
+		return -1
+	}
+	if it != nil {
 		return 1
 	}
 	return 0
@@ -277,10 +281,46 @@ func coraza_add_request_header(t C.coraza_transaction_t, name *C.char, name_len 
 	return 0
 }
 
+// coraza_add_request_headers adds multiple request headers from a packed buffer.
+// Encoding: [name_len u16][name_bytes][value_len u32][value_bytes] × count
+//
+//export coraza_add_request_headers
+func coraza_add_request_headers(t C.coraza_transaction_t, packed *C.char, packed_len C.int, count C.int) C.int {
+	tx := fromRaw[types.Transaction](t)
+	buf := C.GoBytes(unsafe.Pointer(packed), packed_len)
+	off := 0
+	for i := 0; i < int(count); i++ {
+		if off+2 > len(buf) {
+			return -1
+		}
+		nameLen := int(buf[off])<<8 | int(buf[off+1])
+		off += 2
+		if off+nameLen > len(buf) {
+			return -1
+		}
+		name := string(buf[off : off+nameLen])
+		off += nameLen
+		if off+4 > len(buf) {
+			return -1
+		}
+		valueLen := int(buf[off])<<24 | int(buf[off+1])<<16 | int(buf[off+2])<<8 | int(buf[off+3])
+		off += 4
+		if off+valueLen > len(buf) {
+			return -1
+		}
+		value := string(buf[off : off+valueLen])
+		off += valueLen
+		tx.AddRequestHeader(name, value)
+	}
+	return 0
+}
+
 //export coraza_process_request_headers
 func coraza_process_request_headers(t C.coraza_transaction_t) C.int {
 	tx := fromRaw[types.Transaction](t)
-	tx.ProcessRequestHeaders()
+	if it := tx.ProcessRequestHeaders(); it != nil {
+		return 1
+	}
 	return 0
 }
 
@@ -314,6 +354,40 @@ func coraza_add_response_header(t C.coraza_transaction_t, name *C.char, name_len
 	return 0
 }
 
+// coraza_add_response_headers adds multiple response headers from a packed buffer.
+// Same encoding as coraza_add_request_headers.
+//
+//export coraza_add_response_headers
+func coraza_add_response_headers(t C.coraza_transaction_t, packed *C.char, packed_len C.int, count C.int) C.int {
+	tx := fromRaw[types.Transaction](t)
+	buf := C.GoBytes(unsafe.Pointer(packed), packed_len)
+	off := 0
+	for i := 0; i < int(count); i++ {
+		if off+2 > len(buf) {
+			return -1
+		}
+		nameLen := int(buf[off])<<8 | int(buf[off+1])
+		off += 2
+		if off+nameLen > len(buf) {
+			return -1
+		}
+		name := string(buf[off : off+nameLen])
+		off += nameLen
+		if off+4 > len(buf) {
+			return -1
+		}
+		valueLen := int(buf[off])<<24 | int(buf[off+1])<<16 | int(buf[off+2])<<8 | int(buf[off+3])
+		off += 4
+		if off+valueLen > len(buf) {
+			return -1
+		}
+		value := string(buf[off : off+valueLen])
+		off += valueLen
+		tx.AddResponseHeader(name, value)
+	}
+	return 0
+}
+
 //export coraza_append_response_body
 func coraza_append_response_body(t C.coraza_transaction_t, data *C.uchar, length C.int) C.int {
 	tx := fromRaw[types.Transaction](t)
@@ -326,7 +400,11 @@ func coraza_append_response_body(t C.coraza_transaction_t, data *C.uchar, length
 //export coraza_process_response_body
 func coraza_process_response_body(t C.coraza_transaction_t) C.int {
 	tx := fromRaw[types.Transaction](t)
-	if _, err := tx.ProcessResponseBody(); err != nil {
+	it, err := tx.ProcessResponseBody()
+	if err != nil {
+		return -1
+	}
+	if it != nil {
 		return 1
 	}
 	return 0
@@ -335,7 +413,9 @@ func coraza_process_response_body(t C.coraza_transaction_t) C.int {
 //export coraza_process_response_headers
 func coraza_process_response_headers(t C.coraza_transaction_t, status C.int, proto *C.char) C.int {
 	tx := fromRaw[types.Transaction](t)
-	tx.ProcessResponseHeaders(int(status), C.GoString(proto))
+	if it := tx.ProcessResponseHeaders(int(status), C.GoString(proto)); it != nil {
+		return 1
+	}
 	return 0
 }
 
@@ -415,6 +495,15 @@ func coraza_request_body_from_file(t C.coraza_transaction_t, file *C.char) C.int
 func coraza_free_waf(t C.coraza_waf_t) C.int {
 	deleteRaw(t)
 	return 0
+}
+
+// coraza_free_string frees a string returned by libcoraza (e.g. from
+// coraza_matched_rule_get_error_log). Callers must use this instead of
+// libc free() to avoid allocator mismatches on Windows.
+//
+//export coraza_free_string
+func coraza_free_string(s *C.char) {
+	C.free(unsafe.Pointer(s))
 }
 
 /**

--- a/libcoraza/coraza.go
+++ b/libcoraza/coraza.go
@@ -312,7 +312,11 @@ func coraza_add_request_headers(t C.coraza_transaction_t, packed *C.char, packed
 		if off+4 > len(buf) {
 			return C.CORAZA_ERROR
 		}
-		valueLen := int(uint32(buf[off])<<24 | uint32(buf[off+1])<<16 | uint32(buf[off+2])<<8 | uint32(buf[off+3]))
+		vl := uint32(buf[off])<<24 | uint32(buf[off+1])<<16 | uint32(buf[off+2])<<8 | uint32(buf[off+3])
+		if vl > uint32(len(buf)) {
+			return C.CORAZA_ERROR
+		}
+		valueLen := int(vl)
 		off += 4
 		if off+valueLen > len(buf) {
 			return C.CORAZA_ERROR
@@ -388,7 +392,11 @@ func coraza_add_response_headers(t C.coraza_transaction_t, packed *C.char, packe
 		if off+4 > len(buf) {
 			return C.CORAZA_ERROR
 		}
-		valueLen := int(uint32(buf[off])<<24 | uint32(buf[off+1])<<16 | uint32(buf[off+2])<<8 | uint32(buf[off+3]))
+		vl := uint32(buf[off])<<24 | uint32(buf[off+1])<<16 | uint32(buf[off+2])<<8 | uint32(buf[off+3])
+		if vl > uint32(len(buf)) {
+			return C.CORAZA_ERROR
+		}
+		valueLen := int(vl)
 		off += 4
 		if off+valueLen > len(buf) {
 			return C.CORAZA_ERROR

--- a/libcoraza/coraza.go
+++ b/libcoraza/coraza.go
@@ -286,6 +286,9 @@ func coraza_add_request_header(t C.coraza_transaction_t, name *C.char, name_len 
 //
 //export coraza_add_request_headers
 func coraza_add_request_headers(t C.coraza_transaction_t, packed *C.char, packed_len C.int, count C.int) C.int {
+	if packed_len < 0 || count < 0 {
+		return -1
+	}
 	tx := fromRaw[types.Transaction](t)
 	buf := C.GoBytes(unsafe.Pointer(packed), packed_len)
 	off := 0
@@ -293,7 +296,7 @@ func coraza_add_request_headers(t C.coraza_transaction_t, packed *C.char, packed
 		if off+2 > len(buf) {
 			return -1
 		}
-		nameLen := int(buf[off])<<8 | int(buf[off+1])
+		nameLen := int(uint16(buf[off])<<8 | uint16(buf[off+1]))
 		off += 2
 		if off+nameLen > len(buf) {
 			return -1
@@ -303,7 +306,7 @@ func coraza_add_request_headers(t C.coraza_transaction_t, packed *C.char, packed
 		if off+4 > len(buf) {
 			return -1
 		}
-		valueLen := int(buf[off])<<24 | int(buf[off+1])<<16 | int(buf[off+2])<<8 | int(buf[off+3])
+		valueLen := int(uint32(buf[off])<<24 | uint32(buf[off+1])<<16 | uint32(buf[off+2])<<8 | uint32(buf[off+3]))
 		off += 4
 		if off+valueLen > len(buf) {
 			return -1
@@ -359,6 +362,9 @@ func coraza_add_response_header(t C.coraza_transaction_t, name *C.char, name_len
 //
 //export coraza_add_response_headers
 func coraza_add_response_headers(t C.coraza_transaction_t, packed *C.char, packed_len C.int, count C.int) C.int {
+	if packed_len < 0 || count < 0 {
+		return -1
+	}
 	tx := fromRaw[types.Transaction](t)
 	buf := C.GoBytes(unsafe.Pointer(packed), packed_len)
 	off := 0
@@ -366,7 +372,7 @@ func coraza_add_response_headers(t C.coraza_transaction_t, packed *C.char, packe
 		if off+2 > len(buf) {
 			return -1
 		}
-		nameLen := int(buf[off])<<8 | int(buf[off+1])
+		nameLen := int(uint16(buf[off])<<8 | uint16(buf[off+1]))
 		off += 2
 		if off+nameLen > len(buf) {
 			return -1
@@ -376,7 +382,7 @@ func coraza_add_response_headers(t C.coraza_transaction_t, packed *C.char, packe
 		if off+4 > len(buf) {
 			return -1
 		}
-		valueLen := int(buf[off])<<24 | int(buf[off+1])<<16 | int(buf[off+2])<<8 | int(buf[off+3])
+		valueLen := int(uint32(buf[off])<<24 | uint32(buf[off+1])<<16 | uint32(buf[off+2])<<8 | uint32(buf[off+3]))
 		off += 4
 		if off+valueLen > len(buf) {
 			return -1

--- a/libcoraza/coraza.go
+++ b/libcoraza/coraza.go
@@ -293,35 +293,35 @@ func coraza_add_request_header(t C.coraza_transaction_t, name *C.char, name_len 
 //export coraza_add_request_headers
 func coraza_add_request_headers(t C.coraza_transaction_t, packed *C.char, packed_len C.int, count C.int) C.int {
 	if packed_len < 0 || count < 0 {
-		return -1
+		return C.CORAZA_ERROR
 	}
 	tx := fromRaw[types.Transaction](t)
 	buf := C.GoBytes(unsafe.Pointer(packed), packed_len)
 	off := 0
 	for i := 0; i < int(count); i++ {
 		if off+2 > len(buf) {
-			return -1
+			return C.CORAZA_ERROR
 		}
 		nameLen := int(uint16(buf[off])<<8 | uint16(buf[off+1]))
 		off += 2
 		if off+nameLen > len(buf) {
-			return -1
+			return C.CORAZA_ERROR
 		}
 		name := string(buf[off : off+nameLen])
 		off += nameLen
 		if off+4 > len(buf) {
-			return -1
+			return C.CORAZA_ERROR
 		}
 		valueLen := int(uint32(buf[off])<<24 | uint32(buf[off+1])<<16 | uint32(buf[off+2])<<8 | uint32(buf[off+3]))
 		off += 4
 		if off+valueLen > len(buf) {
-			return -1
+			return C.CORAZA_ERROR
 		}
 		value := string(buf[off : off+valueLen])
 		off += valueLen
 		tx.AddRequestHeader(name, value)
 	}
-	return 0
+	return C.CORAZA_OK
 }
 
 //export coraza_process_request_headers
@@ -369,35 +369,35 @@ func coraza_add_response_header(t C.coraza_transaction_t, name *C.char, name_len
 //export coraza_add_response_headers
 func coraza_add_response_headers(t C.coraza_transaction_t, packed *C.char, packed_len C.int, count C.int) C.int {
 	if packed_len < 0 || count < 0 {
-		return -1
+		return C.CORAZA_ERROR
 	}
 	tx := fromRaw[types.Transaction](t)
 	buf := C.GoBytes(unsafe.Pointer(packed), packed_len)
 	off := 0
 	for i := 0; i < int(count); i++ {
 		if off+2 > len(buf) {
-			return -1
+			return C.CORAZA_ERROR
 		}
 		nameLen := int(uint16(buf[off])<<8 | uint16(buf[off+1]))
 		off += 2
 		if off+nameLen > len(buf) {
-			return -1
+			return C.CORAZA_ERROR
 		}
 		name := string(buf[off : off+nameLen])
 		off += nameLen
 		if off+4 > len(buf) {
-			return -1
+			return C.CORAZA_ERROR
 		}
 		valueLen := int(uint32(buf[off])<<24 | uint32(buf[off+1])<<16 | uint32(buf[off+2])<<8 | uint32(buf[off+3]))
 		off += 4
 		if off+valueLen > len(buf) {
-			return -1
+			return C.CORAZA_ERROR
 		}
 		value := string(buf[off : off+valueLen])
 		off += valueLen
 		tx.AddResponseHeader(name, value)
 	}
-	return 0
+	return C.CORAZA_OK
 }
 
 //export coraza_append_response_body


### PR DESCRIPTION
## Summary

Implements the three API improvements from #93:

1. **Interruption signaling** — `coraza_process_request_headers`, `coraza_process_request_body`, `coraza_process_response_headers`, `coraza_process_response_body` now return 1 when interrupted, -1 on error, 0 on success. Callers can skip subsequent phases without polling `coraza_intervention()` on every phase.

2. **Bulk header API** — `coraza_add_request_headers()` and `coraza_add_response_headers()` accept a packed buffer (`[name_len u16][name_bytes][value_len u32][value_bytes] × count`) for single-call header injection.

3. **`coraza_free_string()`** — safe deallocation for strings returned by libcoraza (e.g. `coraza_matched_rule_get_error_log`), avoiding allocator mismatch on Windows.

Ref #93

cc @jptosso @fzipi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk-add headers for request and response flows
  * Library helper to free strings allocated by the library

* **Improvements**
  * Standardized processing return codes for error, interruption, and success

* **Tests**
  * Example tests updated to accept non-negative processing return values and to expect interruption results where applicable
<!-- end of auto-generated comment: release notes by coderabbit.ai -->