### PR TITLE
fix: add foreign to AM_INIT_AUTOMAKE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ AC_INIT([libcoraza],
 AC_CONFIG_MACRO_DIRS([macros build-aux])
 AC_CONFIG_HEADERS([config.h])
 
-AM_INIT_AUTOMAKE([-Wall -Werror])
+AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 
 dnl Disable verbose mode
 dnl To enable, use --disable-silent-rules


### PR DESCRIPTION
## Summary
- Add `foreign` option to `AM_INIT_AUTOMAKE` so automake doesn't require GNU project files (`ChangeLog`, `NEWS`, `AUTHORS`, etc.)
- Without this, `./build.sh` fails on the release tarball with `Makefile.am: error: required file './ChangeLog' not found`

Reported by @airween in digitalwave/ftwrunner#5

cc @jptosso @fzipi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration settings to improve project handling during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->