### PR TITLE
Include <limits.h> in the SWIG wrapper for INT_MAX

### DIFF
--- a/coraza.i
+++ b/coraza.i
@@ -10,6 +10,7 @@
 %{
 /* Include the actual generated header in the wrapper code */
 #include <stdlib.h>
+#include <limits.h>   /* INT_MAX, used by the byte-buffer typemaps */
 #include "coraza/coraza.h"
 %}
 


### PR DESCRIPTION
The byte-buffer typemaps in coraza.i use INT_MAX to guard against
Py_ssize_t/size_t → int truncation, but the %{ %} header block never
includes <limits.h>. It builds for the Python binding and for PUC Lua
because their headers pull in <limits.h> transitively — but LuaJIT's
headers don't, so building the Lua binding against LuaJIT fails with
'INT_MAX' undeclared. This blocks LuaJIT/OpenResty users (e.g. APISIX)
at compile time.

One-line fix: include <limits.h> in the wrapper header block.

Refs #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Made a minor internal update to improve compatibility in generated bindings. No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->