### PR TITLE
feat: export coraza_is_request_body_accessible

### DIFF
--- a/coraza.i
+++ b/coraza.i
@@ -378,6 +378,7 @@ extern int coraza_process_connection(coraza_transaction_t t,
                                      const char *serverHost,
                                      int serverPort);
 extern int coraza_process_request_body(coraza_transaction_t t);
+extern int coraza_is_request_body_accessible(coraza_transaction_t t);
 extern int coraza_update_status_code(coraza_transaction_t t, int code);
 extern int coraza_process_uri(coraza_transaction_t t, const char *uri,
                               const char *method, const char *proto);

--- a/libcoraza/coraza.go
+++ b/libcoraza/coraza.go
@@ -257,6 +257,26 @@ func coraza_process_request_body(t C.coraza_transaction_t) C.int {
 	return C.CORAZA_OK
 }
 
+// coraza_is_request_body_accessible reports whether the engine will inspect the
+// request body, i.e. whether SecRequestBodyAccess is on for this transaction.
+// It is the request-side counterpart of coraza_is_response_body_processable.
+//
+// A connector may call this once after coraza_process_request_headers() and, on
+// 0, skip the coraza_append_request_body()/coraza_request_body_from_file() and
+// coraza_process_request_body() sequence entirely: the engine would discard the
+// body anyway, so skipping only avoids the cgo crossings and the body copies.
+//
+// Returns 1 when the body is accessible, 0 otherwise.
+//
+//export coraza_is_request_body_accessible
+func coraza_is_request_body_accessible(t C.coraza_transaction_t) C.int {
+	tx := fromRaw[types.Transaction](t)
+	if tx.IsRequestBodyAccessible() {
+		return 1
+	}
+	return 0
+}
+
 //export coraza_update_status_code
 func coraza_update_status_code(t C.coraza_transaction_t, code C.int) C.int {
 	tx := fromRaw[types.Transaction](t)

--- a/libcoraza/coraza.go
+++ b/libcoraza/coraza.go
@@ -262,9 +262,16 @@ func coraza_process_request_body(t C.coraza_transaction_t) C.int {
 // It is the request-side counterpart of coraza_is_response_body_processable.
 //
 // A connector may call this once after coraza_process_request_headers() and, on
-// 0, skip the coraza_append_request_body()/coraza_request_body_from_file() and
-// coraza_process_request_body() sequence entirely: the engine would discard the
-// body anyway, so skipping only avoids the cgo crossings and the body copies.
+// 0, skip only the body *submission* calls — coraza_append_request_body() and
+// coraza_request_body_from_file() — because the engine discards those bytes
+// anyway. That saves the per-chunk cgo crossings and the body copies.
+//
+// It must NOT be used to skip coraza_process_request_body(). That call still
+// evaluates the whole request-body rule phase when access is off: core takes the
+// !RequestBodyAccess branch straight to Rules.Eval(PhaseRequestBody), so phase-2
+// rules matching on headers, ARGS or any non-body variable still run there, and
+// the call can still return an interruption. Skipping it would bypass those
+// rules — a fail-open inspection gap, not an optimisation.
 //
 // Returns 1 when the body is accessible, 0 otherwise.
 //

--- a/libcoraza/coraza_test.go
+++ b/libcoraza/coraza_test.go
@@ -463,6 +463,39 @@ func TestProcessRequestBody(t *testing.T) {
 	coraza_free_waf(waf)
 }
 
+// TestIsRequestBodyAccessible asserts both arms of the gate: the directive that
+// turns request-body access off must flip the result. A single-arm test would
+// pass against a stubbed `return 1`, so the Off case is the negative control.
+func TestIsRequestBodyAccessible(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		directives string
+		want       int
+	}{
+		{"on", "SecRequestBodyAccess On", 1},
+		{"off", "SecRequestBodyAccess Off", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			config := coraza_new_waf_config()
+			if rv := coraza_rules_add(config, stringToC(tc.directives)); rv != 0 {
+				t.Fatalf("coraza_rules_add(%q) failed: %d", tc.directives, rv)
+			}
+			waf := coraza_new_waf(config, nil)
+			coraza_free_waf_config(config)
+			if waf == 0 {
+				t.Fatalf("WAF creation failed for %q", tc.directives)
+			}
+			tt := coraza_new_transaction(waf)
+			if got := int(coraza_is_request_body_accessible(tt)); got != tc.want {
+				t.Fatalf("coraza_is_request_body_accessible with %q: got %d, want %d",
+					tc.directives, got, tc.want)
+			}
+			coraza_free_transaction(tt)
+			coraza_free_waf(waf)
+		})
+	}
+}
+
 func TestAddResponseHeader(t *testing.T) {
 	config := coraza_new_waf_config()
 	waf := coraza_new_waf(config, nil)

--- a/libcoraza/coraza_test.go
+++ b/libcoraza/coraza_test.go
@@ -477,21 +477,35 @@ func TestIsRequestBodyAccessible(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			config := coraza_new_waf_config()
+			t.Cleanup(func() { coraza_free_waf_config(config) })
 			if rv := coraza_rules_add(config, stringToC(tc.directives)); rv != 0 {
 				t.Fatalf("coraza_rules_add(%q) failed: %d", tc.directives, rv)
 			}
 			waf := coraza_new_waf(config, nil)
-			coraza_free_waf_config(config)
 			if waf == 0 {
 				t.Fatalf("WAF creation failed for %q", tc.directives)
 			}
+			t.Cleanup(func() { coraza_free_waf(waf) })
 			tt := coraza_new_transaction(waf)
+			t.Cleanup(func() { coraza_free_transaction(tt) })
+
+			// Query the predicate at its documented call site: after the request
+			// headers have been processed, so any phase-1 change to request-body
+			// access is reflected.
+			if rv := coraza_process_uri(tt, stringToC("/test"), stringToC("POST"), stringToC("HTTP/1.1")); rv != 0 {
+				t.Fatalf("coraza_process_uri failed: %d", rv)
+			}
+			if rv := coraza_add_request_header(tt, stringToC("Host"), 4, stringToC("localhost"), 9); rv != 0 {
+				t.Fatalf("coraza_add_request_header failed: %d", rv)
+			}
+			if rv := coraza_process_request_headers(tt); rv != 0 {
+				t.Fatalf("coraza_process_request_headers failed: %d", rv)
+			}
+
 			if got := int(coraza_is_request_body_accessible(tt)); got != tc.want {
 				t.Fatalf("coraza_is_request_body_accessible with %q: got %d, want %d",
 					tc.directives, got, tc.want)
 			}
-			coraza_free_transaction(tt)
-			coraza_free_waf(waf)
 		})
 	}
 }


### PR DESCRIPTION
> Proposal 1 from #118, standalone against `main`. Mirrors #89 (the response-side twin) exactly.

## TL;DR
The engine already knows whether it will bother looking at the request body — that's what `SecRequestBodyAccess` decides. It just never told C connectors. So a connector hands the body over chunk by chunk, pays a cgo crossing each time, and the engine quietly throws it all away. This exports the existing "will you even look at this?" predicate so a connector can ask once and skip the whole handover.

**Type:** Additive API (new symbol, no ABI break — minor bump)

## What
`coraza_is_response_body_processable()` (#89) lets a connector skip response-body buffering and the phase-4 cgo calls when the engine will not inspect the body. There was no request-side counterpart, so C connectors pay the full request-body cost — one `coraza_append_request_body()` crossing per chunk (or `coraza_request_body_from_file()`) plus `coraza_process_request_body()` — even when `SecRequestBodyAccess Off` means none of it is inspected.

The predicate already exists in core as a public interface method: `types.Transaction.IsRequestBodyAccessible()` (`types/transaction.go:165` in v3.7.0, the version pinned in `go.mod`). It was simply never exported through libcoraza. #89 added the response twin standalone; the request side looks like an accidental gap rather than a design decision.

## Change
- `libcoraza/coraza.go` — new `//export coraza_is_request_body_accessible`, same shape as `coraza_is_response_body_processable`:

```go
//export coraza_is_request_body_accessible
func coraza_is_request_body_accessible(t C.coraza_transaction_t) C.int {
	tx := fromRaw[types.Transaction](t)
	if tx.IsRequestBodyAccessible() {
		return 1
	}
	return 0
}
```

- `coraza.i` — matching `extern` declaration. Required: `make check-swig-sync` hard-fails on any `//export` that is not declared in the interface file.
- `libcoraza/coraza_test.go` — two-arm Go unit test.

A connector calls this once after `coraza_process_request_headers()` and, on `0`, skips the whole append/process sequence. Returning `0` never changes inspection semantics — the engine would have discarded the body anyway; only the crossings and the body copies are avoided.

## Honest sizing
`IsRequestBodyAccessible()` reflects `SecRequestBodyAccess` **only**. With the CRS default (`On`) it returns 1 and nothing is skipped — the win applies to deployments that turn request-body access off globally or per-location. For those, a connector saves N chunk crossings + 1 process crossing + the body copies per request.

A fuller mime-aware gate (dodging the cost even with body access on, when the Content-Type will not be processed) is Proposal 2 in #118. That one needs a core-side `IsRequestBodyProcessable()` first, so it is deliberately **not** in this PR. This change stands alone.

## Testing
`TestIsRequestBodyAccessible` is table-driven over both arms — `SecRequestBodyAccess On` → 1, `SecRequestBodyAccess Off` → 0 — because a single-arm test would pass against a stubbed `return 1` and guard nothing.

Negative control verified: stubbing the body to `return 1` fails the test on the `Off` arm exactly as intended, and passes once restored.

```
--- FAIL: TestIsRequestBodyAccessible/off
    coraza_test.go:490: coraza_is_request_body_accessible with "SecRequestBodyAccess Off": got 1, want 0
```

Also verified locally:
- `go test -race ./...` — full suite green.
- `make check-swig-sync` logic — all exports accounted for in `coraza.i`.
- `go tool cgo -exportheader` — the symbol emits into the generated C header next to its twin:
  ```
  extern int coraza_is_request_body_accessible(coraza_transaction_t t);
  extern int coraza_is_response_body_processable(coraza_transaction_t t);
  ```

Note: `gofmt -l` flags `libcoraza/coraza.go` on `main` already (an indentation quirk around line 716, unrelated to this change). Left untouched to keep the diff minimal — happy to fix it in a separate PR.

Closes #118.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a way to determine whether a request body will be inspected for the current transaction.
  * The check reports whether request-body access is enabled or disabled.

* **Tests**
  * Added coverage for both enabled and disabled request-body inspection settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->